### PR TITLE
Add key for current JSON schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The output is JSON and could look like the following:
 
 ```json
 {
+  "schema_version": "1.0",
   "commits_total": 32,
   "matched_total": 14,
   "matched_newest": [

--- a/contribution_checker/_report.py
+++ b/contribution_checker/_report.py
@@ -13,6 +13,7 @@ from dataclasses import asdict, dataclass, field
 class RepoReport:
     """Data class that holds a report about a repository"""
 
+    schema_version: str = "1.0"  # version for the JSON schema in case we introduce breaking changes
     commits_total: int = 0
     matched_total: int = 0
     matched_newest: str = ""


### PR DESCRIPTION
In case we introduce breaking changes to the JSON schema of the output, it's good practice to add a version indicator so downstream users can adapt to these changes.